### PR TITLE
fix: pcm-memory and pcm-power are only supported for xeon platforms. …

### DIFF
--- a/docker/platform/entrypoint.sh
+++ b/docker/platform/entrypoint.sh
@@ -22,7 +22,22 @@ touch /tmp/results/disk_bandwidth.log
 chown 1000:1000 /tmp/results/disk_bandwidth.log
 iotop -o -P -b >& /tmp/results/disk_bandwidth.log &
 
-echo "Starting xeon pcm-power collection"
+is_xeon=`lscpu | grep -i xeon | wc -l`
+
+if [ "$is_xeon"  == "1"  ]
+  then
+    echo "Starting pcm-memory collection"
+    touch /tmp/results/pcm-memory.csv
+    chown 1000:1000 /tmp/results/pcm-memory.csv
+    /opt/intel/pcm-bin/bin/pcm-memory 1 -silent -nc -csv=/tmp/results/pcm-memory.csv &
+
+    echo "Starting pcm-power collection"
+    touch /tmp/results/pcm-power.log
+    chown 1000:1000 /tmp/results/pcm-power.log
+    /opt/intel/pcm-bin/bin/pcm-power >& /tmp/results/pcm-power.log &
+  fi
+
+echo "Starting general pcm collection"
 touch /tmp/results/pcm.csv
 chown 1000:1000 /tmp/results/pcm.csv
 /opt/intel/pcm-bin/bin/pcm 1 -silent -nc -nsys -csv=/tmp/results/pcm.csv


### PR DESCRIPTION
…Added a check to only run these logs on xeon platforms

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Added label to the Pull Request for easier discoverability and search
- [ ] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/performance-tools/blob/main/CONTRIBUTING.md
- [ ] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->
Confirmed that pcm-memory and pcm-power can now run in parallel on xeon platforms. 
Confirmed that pcm-memory and pcm-power are only compatible with xeon platforms.
Added logic to only run pcm-memory and pcm-power on xeon platforms.

## Issue this PR will close

close: #526

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
<!-- How can the reviewers test your change? -->
- cd docker
- make build-all
- make start-platform-tools
- Verify the correct pcm logs are located in /results
    * Xeon: pcm.csv, pcm-memory.csv, pcm-power.log
    * Non-Xeon: pcm.csv

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/performance-tools )
