### PR TITLE
fix: fix the defect about the device card id issue in igt script for NUC system

### DIFF
--- a/docker/intel-top/entrypoint.sh
+++ b/docker/intel-top/entrypoint.sh
@@ -19,7 +19,8 @@ IFS='@'
 for device in $devices
 do
     # shellcheck disable=SC2086 # Intended work splitting
-    dev=$(echo $device | awk '{print $1}')
+    # the real device card number should be from card= instead of the device index string itself
+    dev=$(echo $device | awk '{print $NF}' | sed -E 's/.*?card=//')
     echo "$dev"
     # shellcheck disable=SC2086 # Intended work splitting
     deviceId=$(echo $device | awk '{print $2}' | sed -E 's/.*?device=//' | cut -f1 -d",")


### PR DESCRIPTION
## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/performance-tools/blob/main/CONTRIBUTING.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->
Resolve the igt device index or id issue in igt entrypoint script which causes the output csv igt-xxxx.csv **empty content**: in my NUC the index was not correctly parsed from the original device string and this PR fixes it.


## Issue this PR will close

close: #**issue_number**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
<!-- How can the reviewers test your change? -->
 - git clone this PR
 - change directory to `./docker`: 
 ```console 
cd ./docker
```
 - re-build the docker igt docker image: `make build-igt`
 - run the performance tool: `make start-performance-tools`
 - observed the compose log and output csv file, now it should be normal without error and there is content output in **igt0-xxxx.csv** file
 - 

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/performance-tools )
