### PR TITLE
feat: enhance stream-density mode for the benchmark script to take multiple target_fps and container_names

### DIFF
--- a/benchmark-scripts/Makefile
+++ b/benchmark-scripts/Makefile
@@ -16,5 +16,13 @@ python-test:
 python-integration:
 	python -m coverage run -m unittest benchmark_integration.py
 
-python-coverage:
+# for more up-to-date coverage, run python unit test first
+python-coverage: python-test
 	coverage report -m
+
+# this one is just used for easier deployment of changes on benchmark-scripts
+# to loss-prevention LOCALLY without reaching out to github
+# assuming loss-prevention/ repo is already git cloned before and is
+# in the same parallel directory structure as performance-tools/ repo
+copy-to-loss-prevention:
+	cp -r ./ ../../loss-prevention/performance-tools/benchmark-scripts/

--- a/benchmark-scripts/Makefile
+++ b/benchmark-scripts/Makefile
@@ -19,10 +19,3 @@ python-integration:
 # for more up-to-date coverage, run python unit test first
 python-coverage: python-test
 	coverage report -m
-
-# this one is just used for easier deployment of changes on benchmark-scripts
-# to loss-prevention LOCALLY without reaching out to github
-# assuming loss-prevention/ repo is already git cloned before and is
-# in the same parallel directory structure as performance-tools/ repo
-copy-to-loss-prevention:
-	cp -r ./ ../../loss-prevention/performance-tools/benchmark-scripts/

--- a/benchmark-scripts/stream_density.py
+++ b/benchmark-scripts/stream_density.py
@@ -13,9 +13,12 @@ import sys
 
 # Constants:
 TARGET_FPS_KEY = "TARGET_FPS"
+CONTAINER_NAME_KEY = "CONTAINER_NAME"
 PIPELINE_INCR_KEY = "PIPELINE_INC"
 INIT_DURATION_KEY = "INIT_DURATION"
 RESULTS_DIR_KEY = "RESULTS_DIR"
+DEFAULT_TARGET_FPS = 14.95
+MAX_GUESS_INCREMENTS = 5
 
 
 class ArgumentError(Exception):
@@ -57,12 +60,16 @@ def clean_up_pipeline_logs(results_dir):
         print('INFO: no match files to clean up')
 
 
-def check_non_empty_result_logs(num_pipelines, results_dir, max_retries=5):
+def check_non_empty_result_logs(num_pipelines, results_dir,
+                                container_name, max_retries=5):
     '''
     checks the current non-empty pipeline log files with some
     retries upto max_retires if file not exists or empty
     Args:
         num_pipelines: number of currently running pipelines
+        container_name: the name of the container to match in log files,
+                        expected to be part of the filename pattern
+                        after the underscore (_)
         results_dir: directory holding the benchmark results
         max_retries: maximum number of retires, default 5 retires
     '''
@@ -76,11 +83,13 @@ def check_non_empty_result_logs(num_pipelines, results_dir, max_retries=5):
         print("INFO: checking presence of all pipeline log files... " +
               "retry: {}".format(retry))
         matching_files = glob.glob(os.path.join(
-            results_dir, 'pipeline*_*.log'))
+            results_dir, f'pipeline*_{container_name}.log'))
         if len(matching_files) >= num_pipelines and all([
               os.path.isfile(file) and os.path.getsize(file) > 0
               for file in matching_files]):
-            print('found all non-empty log files')
+            print(
+                f'found all non-empty log files for container name '
+                f'{container_name}')
             break
         else:
             # some log files still empty or not found, retry it
@@ -113,12 +122,15 @@ def get_latest_pipeline_logs(num_pipelines, pipeline_log_files):
     return latest_files
 
 
-def calculate_total_fps(num_pipelines, results_dir):
+def calculate_total_fps(num_pipelines, results_dir, container_name):
     '''
     calculates averaged fps from the current running num_pipelines
     Args:
         num_pipelines: number of currently running pipelines
         results_dir: directory holding the benchmark results
+        container_name: the name of the container to match in log files,
+                        expected to be part of the filename pattern
+                        after the underscore (_)
     Returns:
         total_fps: accumulative total fps from all pipelines
         total_fps_per_stream: the averaged fps for pipelines
@@ -126,7 +138,7 @@ def calculate_total_fps(num_pipelines, results_dir):
     total_fps = 0
     total_fps_per_stream = 0
     matching_files = glob.glob(os.path.join(
-        results_dir, 'pipeline*_*.log'))
+        results_dir, f'pipeline*_{container_name}.log'))
     print(f"DEBUG: num. of matching_files = {len(matching_files)}")
     latest_pipeline_logs = get_latest_pipeline_logs(
         num_pipelines, matching_files)
@@ -150,127 +162,219 @@ def calculate_total_fps(num_pipelines, results_dir):
     return total_fps, total_fps_per_stream
 
 
-def run_stream_density(env_vars, compose_files):
+def validate_and_setup_env(env_vars, target_fps_list):
     '''
-    runs stream density using docker compose for the specified target FPS
-    with optional stream density pipeline increment numbers
+    Validates and sets up the environment variables needed for
+    running stream density.
     Args:
-        env_vars: the dict of current environment variables
-        compose_files: the list of compose files to run pipelines
-    Returns:
-        num_pipelines: maximum number of pipelines to achieve TARGET_FPS
-        meet_target_fps: boolean to indicate whether the returned
-        number_pipelines can achieve the TARGET_FPS goal or not
+        env_vars: dict of current environment variables
+        target_fps_list: list of target FPS values for stream density
     '''
     if not is_env_non_empty(env_vars, RESULTS_DIR_KEY):
         raise ArgumentError('ERROR: missing ' +
                             RESULTS_DIR_KEY + 'in env')
 
-    # use some default values is missing
-    if not is_env_non_empty(env_vars, TARGET_FPS_KEY):
-        env_vars[TARGET_FPS_KEY] = "15.0"
-    elif float(env_vars[TARGET_FPS_KEY]) <= 0.0:
+    # Set default values if missing
+    if not target_fps_list:
+        target_fps_list.append(DEFAULT_TARGET_FPS)
+    elif any(float(fps) <= 0.0 for fps in target_fps_list):
         raise ArgumentError(
-            'ERROR: stream density target fps should be greater than 0')
+            'ERROR: stream density target fps ' +
+            'should be greater than 0')
 
     if is_env_non_empty(env_vars, PIPELINE_INCR_KEY) and int(
             env_vars[PIPELINE_INCR_KEY]) <= 0:
         raise ArgumentError(
-            'ERROR: stream density increments should be greater than 0')
+            'ERROR: stream density increments ' +
+            'should be greater than 0')
 
     if not is_env_non_empty(env_vars, INIT_DURATION_KEY):
         env_vars[INIT_DURATION_KEY] = "120"
 
-    # set up:
-    TARGET_FPS = float(env_vars[TARGET_FPS_KEY])
+
+def run_pipeline_iterations(
+        env_vars, compose_files, results_dir,
+        container_name, target_fps):
+    '''
+    runs an iteration of stream density benchmarking for
+    a given container name and target FPS.
+    Args:
+        env_vars: Environment variables for docker compose.
+        compose_files: Docker compose files.
+        results_dir: Directory for storing results.
+        container_name: Name of the container to run.
+        target_fps: Target FPS to achieve.
+    Returns:
+        num_pipelines: Number of pipelines used.
+        meet_target_fps: Whether the target FPS was achieved.
+    '''
     INIT_DURATION = int(env_vars[INIT_DURATION_KEY])
-    MAX_GUESS_INCREMENTS = 5
     num_pipelines = 1
+    in_decrement = False
+    increments = 1
+    meet_target_fps = False
+
+    # clean up any residual pipeline log files before starts:
+    clean_up_pipeline_logs(results_dir)
+    print(
+        f"INFO: Stream density TARGET_FPS set for {target_fps} "
+        f"with container_name {container_name} "
+        f"and INIT_DURATION set for {INIT_DURATION} seconds")
+
+    while not meet_target_fps:
+        env_vars["PIPELINE_COUNT"] = str(num_pipelines)
+        print(f"Starting num. of pipelines: {num_pipelines}")
+        benchmark.docker_compose_containers(
+            "up", compose_files=compose_files,
+            compose_post_args="-d", env_vars=env_vars)
+        print("waiting for pipelines to settle...")
+        time.sleep(INIT_DURATION)
+        # note: before reading the pipeline log files
+        # we want to give pipelines some time as the log files
+        # producing could be lagging behind...
+        try:
+            check_non_empty_result_logs(
+                num_pipelines, results_dir, container_name, 50)
+        except ValueError as e:
+            print(f"ERROR: {e}")
+            benchmark.docker_compose_containers(
+                "down", compose_files=compose_files,
+                env_vars=env_vars)
+            # since we are not able to get all non-empty log
+            # the best we can do is to use the previous num_pipelines
+            # before this current num_pipelines
+            num_pipelines = num_pipelines - increments
+            if num_pipelines < 1:
+                num_pipelines = 1
+            return num_pipelines, False
+        # once we have all non-empty pipeline log files
+        # we then can calculate the average fps
+        total_fps, total_fps_per_stream = calculate_total_fps(
+            num_pipelines, results_dir, container_name)
+        print('container name:', container_name)
+        print('Total FPS:', total_fps)
+        print(f"Total averaged FPS per stream: {total_fps_per_stream} "
+              f"for {num_pipelines} pipeline(s)")
+
+        if not in_decrement:
+            if total_fps_per_stream >= target_fps:
+                # if the increments hint from $PIPELINE_INC is not empty
+                # we will use it as the increments
+                # otherwise, we will try to adjust increments dynamically
+                # based on the rate of {total_fps_per_stream}
+                # and target_fps
+                if is_env_non_empty(env_vars, PIPELINE_INCR_KEY):
+                    increments = int(env_vars[PIPELINE_INCR_KEY])
+                else:
+                    increments = int(
+                        total_fps_per_stream / target_fps)
+                    if increments == 1:
+                        increments = MAX_GUESS_INCREMENTS
+                    print(
+                        f"incrementing pipeline no. by {increments}")
+            else:
+                # below target_fps, start decrementing
+                increments = -1
+                in_decrement = True
+                print(
+                    f"Below target fps {target_fps}, "
+                    f"starting to decrement pipelines by 1...")
+        else:
+            # in decrementing case:
+            if total_fps_per_stream >= target_fps:
+                print(
+                    f"found maximum number of pipelines to reach "
+                    f"target FPS {target_fps}")
+                meet_target_fps = True
+                print(
+                    f"Max stream density achieved for target FPS "
+                    f"{target_fps} is {num_pipelines}")
+                increments = 0
+            elif num_pipelines <= 1:
+                print(
+                    f"already reached num pipeline 1, and "
+                    f"the fps per stream is {total_fps_per_stream} "
+                    f"but target FPS is {target_fps}")
+                meet_target_fps = False
+                break
+            else:
+                print(
+                    f"decrementing number of pipelines "
+                    f"{num_pipelines} by 1")
+        # end of if not in_decrement:
+        num_pipelines += increments
+        if num_pipelines <= 0:
+            # we will keep the min. num_pipelines as 1
+            num_pipelines = 1
+            print(
+                f"already reached min. pipeline number, stopping...")
+            break
+    # end of while
+    print(
+        f"pipeline iterations done for "
+        f"container_name: {container_name} "
+        f"with input target_fps = {target_fps}"
+    )
+
+    return num_pipelines, meet_target_fps
+
+
+def run_stream_density(env_vars, compose_files, target_fps_list,
+                       container_names_list):
+    '''
+    runs stream density using docker compose for the specified target FPS
+    values and the corresponding container names
+    with optional stream density pipeline increment numbers
+    Args:
+        env_vars: the dict of current environment variables
+        compose_files: the list of compose files to run pipelines
+        target_fps_list: list of target FPS values for stream density
+        container_names_list: list of container names for
+                              the corresponding target FPS
+    Returns:
+        results as a list of tuples (target_fps, container_name,
+                                     num_pipelines, meet_target_fps) where
+        target_fps: the desire frames per second to maintain for pipeline
+        container_name: the corresponding container name for the pipeline
+        num_pipelines: maximum number of pipelines to achieve TARGET_FPS
+        meet_target_fps: boolean to indicate whether the returned
+        number_pipelines can achieve the TARGET_FPS goal or not
+    '''
+    results = []
+    validate_and_setup_env(env_vars, target_fps_list)
     results_dir = env_vars[RESULTS_DIR_KEY]
     log_file_path = os.path.join(results_dir, 'stream_density.log')
     orig_stdout = sys.stdout
     orig_stderr = sys.stderr
     try:
-        logger = open(log_file_path, 'w')
-        sys.stdout = logger
-        sys.stderr = logger
+        with open(log_file_path, 'a') as logger:
+            sys.stdout = logger
+            sys.stderr = logger
 
-        # clean up any residual pipeline log files before starts:
-        clean_up_pipeline_logs(results_dir)
-
-        print(f"INFO: Stream density TARGET_FPS set for {TARGET_FPS} "
-              f"and INIT_DURATION set for {INIT_DURATION}")
-
-        # stream density main logic:
-        in_decrement = False
-        increments = 1
-        meet_target_fps = False
-        while not meet_target_fps:
-            total_fps_per_stream = 0.0
-            total_fps = 0.0
-            env_vars["PIPELINE_COUNT"] = str(num_pipelines)
-            print("Starting num. of pipelines: %d" % num_pipelines)
-            benchmark.docker_compose_containers(
-                "up", compose_files=compose_files,
-                compose_post_args="-d", env_vars=env_vars)
-            print("waiting for pipelines to settle...")
-            time.sleep(INIT_DURATION)
-            # note: before reading the pipeline log files
-            # we want to give pipelines some time as the log files
-            # producing could be lagging behind...
-            check_non_empty_result_logs(num_pipelines, results_dir, 50)
-            # once we have all non-empty pipeline log files
-            # we then can calculate the average fps
-            total_fps, total_fps_per_stream = calculate_total_fps(
-                num_pipelines, results_dir)
-            print('Total FPS:', total_fps)
-            print(
-                f"Total averaged FPS per stream: {total_fps_per_stream} "
-                f"for {num_pipelines} pipeline(s)")
-            if not in_decrement:
-                if total_fps_per_stream >= TARGET_FPS:
-                    # if the increments hint from $PIPELINE_INC is not empty
-                    # we will use it as the increments
-                    # otherwise, we will try to adjust increments dynamically
-                    # based on the rate of {total_fps_per_stream}
-                    # and $TARGET_FPS
-                    if is_env_non_empty(env_vars, PIPELINE_INCR_KEY):
-                        increments = int(env_vars[PIPELINE_INCR_KEY])
-                    else:
-                        increments = int(
-                            total_fps_per_stream / TARGET_FPS)
-                        if increments == 1:
-                            increments = MAX_GUESS_INCREMENTS
-                    print(f"incrementing pipeline no. by {increments}")
-                else:
-                    # below TARGET_FPS, start decrementing
-                    increments = -1
-                    in_decrement = True
-                    print(f"Below target fps {TARGET_FPS}, "
-                          f"starting to decrement pipelines by 1...")
-            else:
-                if total_fps_per_stream >= TARGET_FPS:
-                    print(f"found maximum number of pipelines to reach "
-                          f"target fps {TARGET_FPS}")
-                    meet_target_fps = True
-                    print(f"Max stream density achieved for target FPS "
-                          f"{TARGET_FPS} is {num_pipelines}")
-                    increments = 0
-                    print("Finished stream density benchmarking")
-                else:
-                    if num_pipelines <= 1:
-                        print(f"already reached num pipeline 1, and the "
-                              f"fps per stream is {total_fps_per_stream} "
-                              f"but target FPS is {TARGET_FPS}")
-                        meet_target_fps = False
-                        break
-                    else:
-                        print(f"decrementing number of pipelines "
-                              f"{num_pipelines} by 1")
-            # end of if not in_decrement:
-            num_pipelines += increments
-        # end of while
-        print("stream_density done!")
+            # loop through the target_fps list and find out the stream density:
+            for target_fps, container_name in zip(
+                target_fps_list, container_names_list
+            ):
+                print(
+                    f"DEBUG: in for-loop, target_fps={target_fps} "
+                    f"container_name={container_name}")
+                env_vars[TARGET_FPS_KEY] = str(target_fps)
+                env_vars[CONTAINER_NAME_KEY] = container_name
+                # stream density main logic:
+                num_pipelines, meet_target_fps = run_pipeline_iterations(
+                    env_vars, compose_files, results_dir,
+                    container_name, target_fps
+                )
+                results.append(
+                    (
+                        target_fps,
+                        container_name,
+                        num_pipelines,
+                        meet_target_fps
+                    )
+                )
+            # end of for-loop
+            print("stream_density done!")
     except Exception as ex:
         print(f'ERROR: found exception: {ex}')
         raise
@@ -281,4 +385,5 @@ def run_stream_density(env_vars, compose_files):
         # reset sys stdout and err back to it's own
         sys.stdout = orig_stdout
         sys.stderr = orig_stderr
-    return num_pipelines, meet_target_fps
+
+    return results

--- a/benchmark-scripts/stream_density_test.py
+++ b/benchmark-scripts/stream_density_test.py
@@ -369,9 +369,13 @@ class Testing(unittest.TestCase):
     @patch('stream_density.run_pipeline_iterations')
     @patch('stream_density.benchmark.docker_compose_containers')
     @patch('builtins.open', new_callable=mock_open)
-    def test_run_stream_density(self,
-        mock_open_file, mock_docker_compose,
-        mock_run_pipeline_iterations, mock_validate_env):
+    def test_run_stream_density(
+        self,
+        mock_open_file,
+        mock_docker_compose,
+        mock_run_pipeline_iterations,
+        mock_validate_env
+    ):
         test_cases = [
             # Test case 1: Valid scenario where all parameters are correct
             {

--- a/benchmark-scripts/stream_density_test.py
+++ b/benchmark-scripts/stream_density_test.py
@@ -7,8 +7,16 @@
 import mock
 import subprocess  # nosec B404
 import unittest
+from unittest.mock import patch, mock_open, MagicMock
 import stream_density
+from stream_density import validate_and_setup_env, ArgumentError
 import os
+
+
+RESULTS_DIR_KEY = "RESULTS_DIR"
+PIPELINE_INCR_KEY = "PIPELINE_INC"
+INIT_DURATION_KEY = "INIT_DURATION"
+DEFAULT_TARGET_FPS = 14.95
 
 
 class Testing(unittest.TestCase):
@@ -33,7 +41,7 @@ class Testing(unittest.TestCase):
         # no file at all case:
         try:
             stream_density.check_non_empty_result_logs(
-                1, './non-existing-results')
+                1, './non-existing-results', 'abc')
             self.fail('expected ValueError exception')
         except ValueError as ex:
             self.assertTrue("""ERROR: cannot find all pipeline log files
@@ -49,7 +57,7 @@ class Testing(unittest.TestCase):
             with open(testFile, 'w') as file:
                 file.write('this is a test')
             stream_density.check_non_empty_result_logs(
-                2, test_results_dir)
+                2, test_results_dir, 'abc')
             self.fail('expected ValueError exception')
         except ValueError as ex:
             self.assertTrue("""ERROR: cannot find all pipeline log files
@@ -65,7 +73,7 @@ class Testing(unittest.TestCase):
         testFile1 = os.path.join(
             test_results_dir, 'pipeline12345656_abc.log')
         testFile2 = os.path.join(
-            test_results_dir, 'pipeline98765432_def.log')
+            test_results_dir, 'pipeline98765432_abc.log')
         try:
             os.makedirs(test_results_dir)
             # create two non empty temporary log files
@@ -75,7 +83,9 @@ class Testing(unittest.TestCase):
                 file.write('another file for testing')
 
             stream_density.check_non_empty_result_logs(
-                2, test_results_dir)
+                2, test_results_dir, 'abc')
+            stream_density.check_non_empty_result_logs(
+                2, test_results_dir, 'abc')
         except ValueError as ex:
             self.fail("""ERROR: cannot find all pipeline log files
                     after max retries""")
@@ -91,7 +101,7 @@ class Testing(unittest.TestCase):
         test_results_dir = './test_stream_density_results'
         try:
             fps, avg_fps = stream_density.calculate_total_fps(
-                2, test_results_dir)
+                2, test_results_dir, 'gst')
             self.assertTrue(
                 fps > 0.0,
                 f"total_fps is expected > 0.0 but found {fps}")
@@ -131,6 +141,304 @@ class Testing(unittest.TestCase):
                 os.remove(testFile2)
             if not os.listdir(test_results_dir):
                 os.rmdir(test_results_dir)
+
+    def test_validate_and_setup_env(self):
+        test_cases = [
+            # Test case 1: Valid environment, valid target_fps_list
+            {
+                "env_vars": {RESULTS_DIR_KEY: "/some/path"},
+                "target_fps_list": [20.0],
+                "expect_exception": False,
+                "expected_target_fps_list": [20.0],
+                "expected_env_vars": {
+                    RESULTS_DIR_KEY: "/some/path",
+                    INIT_DURATION_KEY: "120"
+                },
+            },
+            # Test case 2: Missing RESULTS_DIR_KEY in env_vars
+            {
+                "env_vars": {},
+                "target_fps_list": [20.0],
+                "expect_exception": True,
+                "exception_type": ArgumentError,
+            },
+            # Test case 3: Empty target_fps_list (should set to default)
+            {
+                "env_vars": {RESULTS_DIR_KEY: "/some/path"},
+                "target_fps_list": [],
+                "expect_exception": False,
+                "expected_target_fps_list": [DEFAULT_TARGET_FPS],
+                "expected_env_vars": {
+                    RESULTS_DIR_KEY: "/some/path",
+                    INIT_DURATION_KEY: "120"
+                },
+            },
+            # Test case 4: Negative target_fps value in target_fps_list
+            {
+                "env_vars": {RESULTS_DIR_KEY: "/some/path"},
+                "target_fps_list": [-5.0],
+                "expect_exception": True,
+                "exception_type": ArgumentError,
+            },
+            # Test case 5: Missing INIT_DURATION_KEY in env_vars-
+            # should default to "120"
+            {
+                "env_vars": {RESULTS_DIR_KEY: "/some/path"},
+                "target_fps_list": [20.0],
+                "expect_exception": False,
+                "expected_target_fps_list": [20.0],
+                "expected_env_vars": {
+                    RESULTS_DIR_KEY: "/some/path",
+                    INIT_DURATION_KEY: "120"
+                },
+            },
+            # Test case 6: PIPELINE_INCR_KEY <= 0 (should raise exception)
+            {
+                "env_vars": {
+                    RESULTS_DIR_KEY: "/some/path",
+                    PIPELINE_INCR_KEY: "0"
+                },
+                "target_fps_list": [20.0],
+                "expect_exception": True,
+                "exception_type": ArgumentError,
+            },
+        ]
+
+        for i, test_case in enumerate(test_cases):
+            with self.subTest(f"Test case {i + 1}"):
+                # Make a copy to avoid mutation
+                env_vars = test_case["env_vars"].copy()
+                target_fps_list = test_case["target_fps_list"].copy()
+
+                if test_case["expect_exception"]:
+                    with self.assertRaises(test_case["exception_type"]):
+                        validate_and_setup_env(env_vars, target_fps_list)
+                else:
+                    try:
+                        validate_and_setup_env(env_vars, target_fps_list)
+                        # Verify the target_fps_list was updated as expected
+                        self.assertEqual(
+                            target_fps_list,
+                            test_case["expected_target_fps_list"])
+                        # Verify env_vars was updated as expected
+                        expected_env_vars = test_case["expected_env_vars"]
+                        for key, value in expected_env_vars.items():
+                            self.assertEqual(env_vars.get(key), value)
+                    except Exception as ex:
+                        self.fail(f"Unexpected exception raised: {ex}")
+
+    @patch('time.sleep', return_value=None)
+    @patch('benchmark.docker_compose_containers')
+    @patch('stream_density.calculate_total_fps')
+    @patch('stream_density.check_non_empty_result_logs')
+    @patch('stream_density.clean_up_pipeline_logs')
+    def test_pipeline_iterations(
+        self,
+        mock_clean_logs,
+        mock_check_logs,
+        mock_calculate_fps,
+        mock_docker_compose,
+        mock_sleep
+    ):
+        test_cases = [
+            # Test case 1: Succeed on the first iteration
+            # with target_fps achieved
+            {
+                "env_vars": {"INIT_DURATION": "10"},
+                "compose_files": ["docker-compose.yml"],
+                "results_dir": "/path/to/results",
+                "container_name": "above_fps_target",
+                "target_fps": 14.0,
+                "expected_num_pipelines": 10,
+                "expected_meet_target_fps": True,
+                # Mock returns FPS below target
+                "calculate_fps_side_effect": [
+                    (50, 20.0), (70, 16.0), (100, 12.0), (120, 14.8)
+                ]
+            },
+            # Test case 2: Reach minimum pipeline count
+            # without achieving target_fps
+            {
+                "env_vars": {"INIT_DURATION": "10"},
+                "compose_files": ["docker-compose.yml"],
+                "results_dir": "/path/to/results",
+                "container_name": "below_fps_target",
+                "target_fps": 15.0,
+                "expected_num_pipelines": 1,
+                "expected_meet_target_fps": False,
+                # Mock returns FPS below target
+                "calculate_fps_side_effect": [(100, 10.0), (50, 5.0)]
+            },
+            # Test case 3: Below target_fps and come back
+            {
+                "env_vars": {"INIT_DURATION": "10", "PIPELINE_INC": "1"},
+                "compose_files": ["docker-compose.yml"],
+                "results_dir": "/path/to/results",
+                "container_name": "below_comeback_target",
+                "target_fps": 14.0,
+                "expected_num_pipelines": 1,
+                "expected_meet_target_fps": True,
+                # Mock returns FPS below target
+                "calculate_fps_side_effect": [
+                    (100, 60.0), (190, 10.0), (320, 14.2)
+                ]
+            },
+            # Test case 4: Below target_fps and reach minimum
+            {
+                "env_vars": {"INIT_DURATION": "10", "PIPELINE_INC": "1"},
+                "compose_files": ["docker-compose.yml"],
+                "results_dir": "/path/to/results",
+                "container_name": "below_comeback_target",
+                "target_fps": 14.0,
+                "expected_num_pipelines": 1,
+                "expected_meet_target_fps": False,
+                # Mock returns FPS below target
+                "calculate_fps_side_effect": [
+                    (100, 60.0), (190, 10.0), (220, 13.2)
+                ]
+            },
+            # Test case 5: check_non_empty_result_logs raises ValueError
+            {
+                "env_vars": {"INIT_DURATION": "10"},
+                "compose_files": ["docker-compose.yml"],
+                "results_dir": "/path/to/results",
+                "container_name": "value_error",
+                "target_fps": 14.0,
+                "check_logs_side_effect": ValueError(
+                    "Expecting ValueError for check_non_empty_result_logs"),
+                "expected_num_pipelines": 1,
+                "expected_meet_target_fps": False
+            },
+        ]
+
+        for i, test_case in enumerate(test_cases):
+            with self.subTest(f"Test case {i + 1}"):
+                env_vars = test_case["env_vars"]
+                compose_files = test_case["compose_files"]
+                results_dir = test_case["results_dir"]
+                container_name = test_case["container_name"]
+                target_fps = test_case["target_fps"]
+
+                # Set up the side effect for
+                # check_non_empty_result_logs if specified
+                if "check_logs_side_effect" in test_case:
+                    mock_check_logs.side_effect = test_case[
+                        "check_logs_side_effect"]
+
+                # Set up the side effect for
+                # calculate_total_fps using a finite list
+                if "calculate_fps_side_effect" in test_case:
+                    mock_calculate_fps.side_effect = test_case[
+                        "calculate_fps_side_effect"]
+
+                # Run the function with the test case inputs
+                if "check_logs_side_effect" in test_case:
+                    num_pipelines, meet_target_fps = (
+                        stream_density.run_pipeline_iterations(
+                            env_vars, compose_files, results_dir,
+                            container_name, target_fps)
+                    )
+
+                    # Verify the returned values after ValueError is handled
+                    self.assertEqual(
+                        num_pipelines,
+                        test_case["expected_num_pipelines"])
+                    self.assertEqual(
+                        meet_target_fps,
+                        test_case["expected_meet_target_fps"])
+
+                    # Ensure that check_non_empty_result_logs was
+                    # called and raised ValueError
+                    mock_check_logs.assert_called()
+                else:
+                    num_pipelines, meet_target_fps = (
+                        stream_density.run_pipeline_iterations(
+                            env_vars, compose_files, results_dir,
+                            container_name, target_fps)
+                    )
+
+                    # Verify the output
+                    self.assertEqual(
+                        num_pipelines,
+                        test_case["expected_num_pipelines"])
+                    self.assertEqual(
+                        meet_target_fps,
+                        test_case["expected_meet_target_fps"])
+
+    @patch('stream_density.validate_and_setup_env')
+    @patch('stream_density.run_pipeline_iterations')
+    @patch('stream_density.benchmark.docker_compose_containers')
+    @patch('builtins.open', new_callable=mock_open)
+    def test_run_stream_density(self,
+        mock_open_file, mock_docker_compose,
+        mock_run_pipeline_iterations, mock_validate_env):
+        test_cases = [
+            # Test case 1: Valid scenario where all parameters are correct
+            {
+                "env_vars": {RESULTS_DIR_KEY: "/some/path"},
+                "compose_files": ["docker-compose.yml"],
+                "target_fps_list": [15.0, 25.0],
+                "container_names_list": ["container1", "container2"],
+                "run_pipeline_side_effect": [
+                    (5, True),  # For container1
+                    (7, False)  # For container2
+                ],
+                "expected_results": [
+                    (15.0, "container1", 5, True),
+                    (25.0, "container2", 7, False)
+                ]
+            },
+            # Test case 2: Exception occurs during run_pipeline_iterations()
+            {
+                "env_vars": {RESULTS_DIR_KEY: "/some/path"},
+                "compose_files": ["docker-compose.yml"],
+                "target_fps_list": [15.0],
+                "container_names_list": ["container1"],
+                "run_pipeline_side_effect": Exception("Test exception"),
+                "expect_exception": True
+            }
+        ]
+
+        for i, test_case in enumerate(test_cases):
+            with self.subTest(f"Test case {i + 1}"):
+                env_vars = test_case["env_vars"].copy()
+                compose_files = test_case["compose_files"]
+                target_fps_list = test_case["target_fps_list"]
+                container_names_list = test_case["container_names_list"]
+
+                # Mock the behavior of run_pipeline_iterations
+                # based on the test case
+                if isinstance(test_case["run_pipeline_side_effect"], list):
+                    mock_run_pipeline_iterations.side_effect = test_case[
+                        "run_pipeline_side_effect"]
+                else:
+                    mock_run_pipeline_iterations.side_effect = test_case[
+                        "run_pipeline_side_effect"]
+
+                # Run the function and verify results or exceptions
+                if test_case.get("expect_exception"):
+                    print('expecting exception test case')
+                    with self.assertRaises(Exception) as context:
+                        stream_density.run_stream_density(
+                            env_vars, compose_files,
+                            target_fps_list, container_names_list)
+                    self.assertTrue(isinstance(context.exception, Exception))
+                else:
+                    results = stream_density.run_stream_density(
+                        env_vars, compose_files,
+                        target_fps_list, container_names_list)
+                    self.assertEqual(results, test_case["expected_results"])
+
+                # Verify that validate_and_setup_env was called correctly
+                mock_validate_env.assert_called_with(
+                    env_vars, target_fps_list
+                )
+
+                # Verify that docker_compose_containers is called with
+                # "down" at the end
+                mock_docker_compose.assert_called_with(
+                    "down", compose_files=compose_files, env_vars=env_vars
+                )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
this pr to add new capabilities for parallel running different case pipelines for stream density mode and added unit tests

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/performance-tools/blob/main/CONTRIBUTING.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [x] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->

## Issue this PR will close

close: #**issue_number**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
<!-- How can the reviewers test your change? -->
- git clone this PR
- change directory to **benchmark-scripts**: `cd ./benchmark-scripts`
- re-build the python packages:
```console
make init-packages
```
- run unit tests:
```console
make python-test
```
you should see all unit tests are PASSED and OK
- run coverage:
```console
make python-coverage
```
so that you can see the code coverage of the stream_density.py 

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/performance-tools )
