### PR TITLE
feat: Separate parsing scripts to accommodate additional data formats

### DIFF
--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -32,8 +32,7 @@ jobs:
             pip install bandit && bandit --version
         - name: Install pep8
           run: |
-              sudo apt install pep8
-              shell: /usr/bin/bash -e (0)
+              sudo apt install pycodestyle
         - name: Install hadolint
           env:
             HADOLINT_VERSION: v1.16.3

--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -33,6 +33,7 @@ jobs:
         - name: Install pep8
           run: |
               sudo apt install pep8
+              shell: /usr/bin/bash -e (0)
         - name: Install hadolint
           env:
             HADOLINT_VERSION: v1.16.3

--- a/benchmark-scripts/benchmark.py
+++ b/benchmark-scripts/benchmark.py
@@ -69,6 +69,14 @@ def parse_args(print=False):
                         default=os.path.join(
                             os.curdir, '..', '..'),
                         help='full path to the retail-use-cases repo root')
+    parser.add_argument('--docker_log', default=None, 
+                        help='docker container name to get logs of and save to file')
+    parser.add_argument('--parser_script', 
+                        default=os.path.join(os.path.curdir, 'parse_csv_to_json.py'), 
+                        help='full path to the parsing script')
+    parser.add_argument('--parser_args', default='-k device -k igt', 
+                        help='arguments to pass to the parser script, ' + 
+                        'pass args with spaces in quotes: "args with spaces"')
     if print:
         parser.print_help()
         return
@@ -121,27 +129,6 @@ def docker_compose_containers(command, compose_files=[], compose_pre_args="",
         print("Exception bringing %s the compose files: %s" %
               (command, traceback.format_exc()))
 
-
-def convert_csv_results_to_json(results_dir, log_name):
-    '''
-    convert the csv output to json format for readability
-
-    Args:
-        results_dir: directory containing the benchmark results
-        log_name: first portion of the log filename to search for
-    '''
-    for entry in os.scandir(results_dir):
-        if entry.name.startswith(log_name) and entry.is_file():
-            print(entry.path)
-            csv_file = open(entry.path)
-            json_file = json.dumps([dict(r) for r in csv.DictReader(csv_file)])
-            device_name = entry.name.split('.')
-            json_result_path = os.path.join(
-                results_dir, device_name[0]+".json")
-            with open(json_result_path, "w") as outfile:
-                outfile.write(json_file)
-            outfile.close()
-            csv_file.close()
 
 
 def main():
@@ -225,14 +212,32 @@ def main():
         docker_compose_containers("up", compose_files=compose_files,
                                   compose_post_args="-d",
                                   env_vars=env_vars)
-        print("Waiting for init duration to complete...")
+        print("Waiting for %ds init duration to complete" % my_args.init_duration)
         time.sleep(my_args.init_duration)
 
         # use duration to sleep
         print(
-            "Waiting for %d seconds for workload to finish"
+            "Waiting for %ds for workload to finish"
             % my_args.duration)
         time.sleep(my_args.duration)
+        
+        # grab the container logs if necessary
+        if my_args.docker_log:
+            try:
+                docker_log = ("docker logs %s" % my_args.docker_log)
+                docker_log_args = shlex.split(docker_log)
+                log_file = os.path.join(my_args.results_dir, "%s.log" % my_args.docker_log)    
+                print("writing docker log to %s" % log_file)
+                with open(log_file, 'wb') as f:
+                    subprocess.run(docker_log_args,
+                                   stdout=f,
+                                   stderr=subprocess.STDOUT,
+                                   check=True, env=env_vars)  # nosec B404, B603
+            
+            except subprocess.CalledProcessError:
+                print("Exception getting the docker log %s: %s" %
+                    (my_args.docker_log, traceback.format_exc()))        
+        
         # stop all containers and camera-simulator
         docker_compose_containers("down", compose_files=compose_files,
                                   env_vars=env_vars)
@@ -240,10 +245,18 @@ def main():
     # collect metrics using copy-platform-metrics
     print("workloads finished...")
     # TODO: implement results handling based on what pipeline is run
-    # convert xpum results to json
-    convert_csv_results_to_json(results_dir, 'device')
-    # convert igt results to json
-    convert_csv_results_to_json(results_dir, 'igt')
+    try:
+        parser_string = ("python %s -d %s %s" % (my_args.parser_script, results_dir, my_args.parser_args))
+        print("======DEBUG======: %s" % parser_string)
+        parser_args = shlex.split(parser_string)
+
+        subprocess.run(parser_args,
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE,
+                       check=True, env=env_vars)  # nosec B404, B603
+    except subprocess.CalledProcessError:
+        print("Exception starting the parser %s: %s" %
+              (my_args.parser_script, traceback.format_exc()))
 
 if __name__ == '__main__':
     main()

--- a/benchmark-scripts/benchmark.py
+++ b/benchmark-scripts/benchmark.py
@@ -247,7 +247,7 @@ def main():
     # TODO: implement results handling based on what pipeline is run
     try:
         parser_string = ("python %s -d %s %s" % (my_args.parser_script, results_dir, my_args.parser_args))
-        print("======DEBUG======: %s" % parser_string)
+        # print("======DEBUG======: %s" % parser_string)
         parser_args = shlex.split(parser_string)
 
         subprocess.run(parser_args,

--- a/benchmark-scripts/benchmark.py
+++ b/benchmark-scripts/benchmark.py
@@ -1,5 +1,5 @@
 '''
-* Copyright (C) 2024 Intel Corporation.
+* Copyright (C) 2025 Intel Corporation.
 *
 * SPDX-License-Identifier: Apache-2.0
 '''
@@ -73,7 +73,7 @@ def parse_args(print=False):
                         help='docker container name to get logs of and save to file')
     parser.add_argument('--parser_script', 
                         default=os.path.join(os.path.curdir, 'parse_csv_to_json.py'), 
-                        help='full path to the parsing script')
+                        help='full path to the parsing script to obtain FPS')
     parser.add_argument('--parser_args', default='-k device -k igt', 
                         help='arguments to pass to the parser script, ' + 
                         'pass args with spaces in quotes: "args with spaces"')
@@ -251,12 +251,10 @@ def main():
         parser_args = shlex.split(parser_string)
 
         subprocess.run(parser_args,
-                       stdout=subprocess.PIPE,
-                       stderr=subprocess.PIPE,
                        check=True, env=env_vars)  # nosec B404, B603
     except subprocess.CalledProcessError:
-        print("Exception starting the parser %s: %s" %
-              (my_args.parser_script, traceback.format_exc()))
+        print("Exception calling %s\n parser %s: %s" %
+              (parser_string, my_args.parser_script, traceback.format_exc()))
 
 if __name__ == '__main__':
     main()

--- a/benchmark-scripts/parse_csv_to_json.py
+++ b/benchmark-scripts/parse_csv_to_json.py
@@ -1,0 +1,54 @@
+'''
+* Copyright (C) 2025 Intel Corporation.
+*
+* SPDX-License-Identifier: Apache-2.0
+'''
+
+import argparse
+import csv
+import json
+import os
+
+def parse_args():
+
+    parser = argparse.ArgumentParser(
+        prog='parse_csv_to_json', 
+        description='parses csv output to json')
+    parser.add_argument('--directory', '-d', 
+                        default=os.path.join(os.curdir, 'results'),
+                        help='full path to the directory with the results')
+    parser.add_argument('--keyword', '-k', default=['device'], action='append',
+                        help='keyword that results file(s) start with, ' +
+                        'can be used multiple times')
+    return parser.parse_args()
+
+
+def convert_csv_results_to_json(results_dir, log_name):
+    '''
+    convert the csv output to json format for readability
+
+    Args:
+        results_dir: directory containing the benchmark results
+        log_name: first portion of the log filename to search for
+    '''
+    for entry in os.scandir(results_dir):
+        if entry.name.startswith(log_name) and entry.is_file():
+            print(entry.path)
+            csv_file = open(entry.path)
+            json_file = json.dumps([dict(r) for r in csv.DictReader(csv_file)])
+            device_name = entry.name.split('.')
+            json_result_path = os.path.join(
+                results_dir, device_name[0]+".json")
+            with open(json_result_path, "w") as outfile:
+                outfile.write(json_file)
+            outfile.close()
+            csv_file.close()
+
+def main():
+    my_args = parse_args()
+    for k in my_args.keyword:
+        convert_csv_results_to_json(my_args.directory, k)
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmark-scripts/parse_docker_log.py
+++ b/benchmark-scripts/parse_docker_log.py
@@ -8,6 +8,7 @@ import argparse
 import csv
 import json
 import os
+import pprint
 
 def parse_args():
 
@@ -32,7 +33,7 @@ def parse_fps_from_log(results_dir, log_name):
         log_name: first portion of the log filename to search for
     '''
     for entry in os.scandir(results_dir):
-        if entry.name.startswith(log_name) and entry.is_file():
+        if entry.name.startswith(log_name) and entry.is_file() and not entry.name.endswith("json"):
             print(entry.path)
             fps_info = dict()
             count = 0
@@ -56,7 +57,7 @@ def parse_fps_from_log(results_dir, log_name):
                 total_fps += fps_info[sum]
                 fps_info.pop(sum)
             fps_info["avg_fps"] = total_fps/(count * len(sum_list))
-            # TODO: how do we want to save the FPS information?
+            pprint.pp(fps_info)
             outfile = os.path.join(os.path.split(entry.path)[0], "%s.json" % entry.name.split(".")[0])
             with open(outfile, "w") as output:
                 json.dump(fps_info, output)

--- a/benchmark-scripts/parse_docker_log.py
+++ b/benchmark-scripts/parse_docker_log.py
@@ -1,0 +1,71 @@
+'''
+* Copyright (C) 2025 Intel Corporation.
+*
+* SPDX-License-Identifier: Apache-2.0
+'''
+
+import argparse
+import csv
+import json
+import os
+
+def parse_args():
+
+    parser = argparse.ArgumentParser(
+        prog='parse_docker_log', 
+        description='parses docker output to json')
+    parser.add_argument('--directory', '-d', 
+                        default=os.path.join(os.curdir, 'results'),
+                        help='full path to the directory with the results')
+    parser.add_argument('--keyword', '-k', default=['device'], action='append',
+                        help='keyword that results file(s) start with, ' +
+                        'can be used multiple times')
+    return parser.parse_args()
+
+
+def parse_fps_from_log(results_dir, log_name):
+    '''
+    parses the log output for FPS information
+
+    Args:
+        results_dir: directory containing the benchmark results
+        log_name: first portion of the log filename to search for
+    '''
+    for entry in os.scandir(results_dir):
+        if entry.name.startswith(log_name) and entry.is_file():
+            print(entry.path)
+            fps_info = dict()
+            count = 0
+            sum_list = list()
+            with open(entry, "r") as f:
+                for line in f:
+                    words = line.split()
+                    if "FPS" in line:
+                        count += 1
+                        fps_indices = [i for i, x in enumerate(words) if x == "FPS"]
+                        for fps in fps_indices:
+                            #fps_info[words[fps - 1]] = float(words[fps + 1])
+                            if "sum_%s" % words[fps - 1] not in fps_info:
+                                fps_info["sum_%s" % words[fps - 1]] = 0
+                                sum_list.append("sum_%s" % words[fps - 1])
+                            fps_info["sum_%s" % words[fps - 1]] += float(words[fps + 1])
+            total_fps = 0.0
+            for sum in sum_list:
+                name = sum.split('sum_')[-1]
+                fps_info["avg_%s" % name] = fps_info[sum]/count
+                total_fps += fps_info[sum]
+                fps_info.pop(sum)
+            fps_info["avg_fps"] = total_fps/(count * len(sum_list))
+            # TODO: how do we want to save the FPS information?
+            outfile = os.path.join(os.path.split(entry.path)[0], "%s.json" % entry.name.split(".")[0])
+            with open(outfile, "w") as output:
+                json.dump(fps_info, output)
+
+def main():
+    my_args = parse_args()
+    for k in my_args.keyword:
+        parse_fps_from_log(my_args.directory, k)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [ ] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/performance-tools/blob/main/CONTRIBUTING.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->
Updated the parsing to separate the function into a new file that can be passed in to the benchmark script with its arguments

## Issue this PR will close

close: #**issue_number**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
<!-- How can the reviewers test your change? -->
to test, run from the benchmark-scripts dir: 
```
python benchmark.py --compose_file <path-to-scenescape>/docker-compose_yolov8s.yml --docker_log scenescape-queuing-video-1.json --parser_script ./parse_docker_log.py --parser_args "-k scenescape"
```

Depending on your system, you may need to adjust the init duration (90s) and workload (60s) to get data.
The output should be a log file with the scenescape docker log and a json file with the average fps information.

to test without scenescape

```
python benchmark.py --compose_file <desired file> 
```

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/performance-tools )
