### PR TITLE
Fix: Reset PMU between container runs

### DIFF
--- a/docker/platform/entrypoint.sh
+++ b/docker/platform/entrypoint.sh
@@ -40,7 +40,7 @@ if [ "$is_xeon"  == "1"  ]
 echo "Starting general pcm collection"
 touch /tmp/results/pcm.csv
 chown 1000:1000 /tmp/results/pcm.csv
-/opt/intel/pcm-bin/bin/pcm 1 -silent -nc -nsys -csv=/tmp/results/pcm.csv &
+/opt/intel/pcm-bin/bin/pcm 1 -silent -r -nc -nsys -csv=/tmp/results/pcm.csv &
 
 while true
 do


### PR DESCRIPTION
**PR Description:**
This PR adds the -r (--reset) option to the Intel PCM launch command to reset the Performance Monitoring Unit (PMU) before each execution. This change addresses a recurring issue where PCM fails to start or capture data in subsequent Docker container runs due to PMU registers being locked or already in use.

**Problem**
When running PCM in a Docker container, the PMU state from a previous container execution may persist on the host. Since PMU registers are not automatically released, this results in:

**PCM errors like:**
"Access to Intel(r) Performance Counter Monitor has denied (Performance Monitoring Unit is occupied by other application)"

Inconsistent or missing metrics

Logs showing MSR conflicts (e.g., MSR_PERF_GLOBAL_INUSE warnings)

**Fix**
Reset PMU between container runs


ISSUE LINK: https://github.com/intel-retail/performance-tools/issues/117 , https://github.com/intel-retail/performance-tools/issues/125
