### PR TITLE
fix(enhancement): Added per stream fps threshold logic

### DIFF
--- a/benchmark-scripts/stream_density.py
+++ b/benchmark-scripts/stream_density.py
@@ -44,9 +44,7 @@ def build_per_stream_target_fps(stream_fps_dict, default_target_fps):
     # Get camera config path
     camera_stream = os.getenv(CAMERA_STREAM_KEY, "camera_to_workload.json")
     
-    config_path = camera_stream if os.path.isabs(camera_stream) else os.path.normpath(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "configs", camera_stream)
-    )
+    config_path = camera_stream if os.path.isabs(camera_stream) else os.path.abspath(camera_stream)
     
     # Build unified stream index -> target FPS mapping
     stream_idx_to_target_fps = {}

--- a/benchmark-scripts/stream_density.py
+++ b/benchmark-scripts/stream_density.py
@@ -717,7 +717,8 @@ def run_pipeline_iterations(
             print('fail_thresholds:', fail_thresholds)
             print('passing_streams:', passing_streams)
             print('failing_streams:', failing_streams)
-        print("INFO: All streams meet target" if all_streams_meet_target else "INFO: Not all streams meet target")
+        if os.getenv("STREAM_DENSITY_DEBUG", "0") == "1":
+            print("INFO: All streams meet target" if all_streams_meet_target else "INFO: Not all streams meet target")
 
         if not in_decrement:
             if all_streams_meet_target:
@@ -733,6 +734,8 @@ def run_pipeline_iterations(
                     if os.getenv("STREAM_DENSITY_DEBUG", "0") == "1":
                         print('mean target fps:', average_target_fps)
                     increments = int(conservative_per_stream / average_target_fps)
+                    if increments <= 0:
+                        increments = 1
                     if increments == 1:
                         increments = MAX_GUESS_INCREMENTS
                 print(

--- a/benchmark-scripts/stream_density.py
+++ b/benchmark-scripts/stream_density.py
@@ -77,10 +77,14 @@ def build_per_stream_target_fps(stream_fps_dict, default_target_fps):
                 build_per_stream_target_fps._camera_config_cache = cache
             except (IOError, ValueError) as e:
                 print(f"WARN: Failed to load camera config {config_path}: {e}")
+                cache[cache_key] = ({}, 0)
+                build_per_stream_target_fps._camera_config_cache = cache
         else:
             print(
                 f"WARN: camera configuration not found at {config_path}. Using default target FPS for all streams."
             )
+            cache[cache_key] = ({}, 0)
+            build_per_stream_target_fps._camera_config_cache = cache
             
     # Compile regex once (if needed for stream name parsing)
     stream_pattern = re.compile(r"pipeline_stream(\d+)")

--- a/benchmark-scripts/stream_density.py
+++ b/benchmark-scripts/stream_density.py
@@ -82,7 +82,8 @@ def build_per_stream_target_fps(stream_fps_dict, default_target_fps):
             target_fps = default_target_fps
         per_stream_targets[stream_name] = float(target_fps)
     
-    print(f"INFO: per-stream target FPS map: {per_stream_targets}")
+    if os.getenv("STREAM_DENSITY_DEBUG", "0") == "1":
+         print(f"INFO: per-stream target FPS map: {per_stream_targets}")
     return per_stream_targets
 
 def get_mean_target_fps(stream_target_fps, fallback_target_fps):
@@ -693,11 +694,12 @@ def run_pipeline_iterations(
             name: fps for name, fps in stream_fps_dict.items()
             if fps < fail_thresholds[name]
         }
-        print('pass_thresholds:', pass_thresholds)
-        print('fail_thresholds:', fail_thresholds)
-        print('passing_streams:', passing_streams)
-        print('failing_streams:', failing_streams)
         all_streams_meet_target = len(passing_streams) == len(stream_fps_dict)
+        if os.getenv("STREAM_DENSITY_DEBUG", "0") == "1":
+             print('pass_thresholds:', pass_thresholds)
+             print('fail_thresholds:', fail_thresholds)
+             print('passing_streams:', passing_streams)
+             print('failing_streams:', failing_streams)
         print("INFO: All streams meet target" if all_streams_meet_target else "INFO: Not all streams meet target")
 
         if not in_decrement:

--- a/benchmark-scripts/stream_density.py
+++ b/benchmark-scripts/stream_density.py
@@ -62,7 +62,7 @@ def build_per_stream_target_fps(stream_fps_dict, default_target_fps):
         total_cameras = 0
         if os.path.isfile(config_path):
             try:
-                with open(config_path, "r") as f:
+                with open(config_path, "r", encoding="utf-8") as f:
                     cameras = json.load(f).get("lane_config", {}).get("cameras", [])
                 total_cameras = len(cameras)
                 for idx, cam in enumerate(cameras):

--- a/benchmark-scripts/stream_density.py
+++ b/benchmark-scripts/stream_density.py
@@ -13,6 +13,7 @@ import sys
 import re
 import statistics
 import psutil
+import json 
 
 # Constants:
 TARGET_FPS_KEY = "TARGET_FPS"
@@ -32,10 +33,61 @@ PASS_TOLERANCE_RATIO_KEY = "PASS_TOLERANCE_RATIO"
 DEFAULT_FPS_SAMPLE_WINDOW = 60
 DEFAULT_HYSTERESIS_FPS = 0.10
 DEFAULT_PASS_TOLERANCE_RATIO = 0.95
+CAMERA_STREAM_KEY = "CAMERA_STREAM"
 
 
 class ArgumentError(Exception):
     pass
+
+def build_per_stream_target_fps(stream_fps_dict, default_target_fps):
+    """Build stream-level FPS targets from camera config."""
+    # Get camera config path
+    camera_stream = os.getenv(CAMERA_STREAM_KEY, "camera_to_workload.json")
+    
+    config_path = camera_stream if os.path.isabs(camera_stream) else os.path.normpath(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "configs", camera_stream)
+    )
+    
+    # Build unified stream index -> target FPS mapping
+    stream_idx_to_target_fps = {}
+    total_cameras = 0
+    if os.path.isfile(config_path):
+        try:
+            with open(config_path, "r") as f:
+                cameras = json.load(f).get("lane_config", {}).get("cameras", [])
+            total_cameras = len(cameras)
+            for idx, cam in enumerate(cameras):
+                if isinstance(cam, dict):
+                    try:
+                        fps_value = float(cam.get("targetFps", 0))
+                        if fps_value > 0:
+                            stream_idx_to_target_fps[idx] = fps_value
+                    except (TypeError, ValueError):
+                        pass
+        except (IOError, ValueError) as e:
+            print(f"WARN: Failed to load camera config {config_path}: {e}")
+    else:
+        print(f"WARN: camera configuration not found at {config_path}. Using default target FPS for all streams.")
+    
+    # Compile regex once (if needed for stream name parsing)
+    stream_pattern = re.compile(r"pipeline_stream(\d+)")
+    per_stream_targets = {}
+
+    for stream_name in stream_fps_dict:
+        match = stream_pattern.search(stream_name)
+        if match and total_cameras > 0:
+            camera_idx = int(match.group(1)) % total_cameras
+            target_fps = stream_idx_to_target_fps.get(camera_idx, default_target_fps)
+        else:
+            target_fps = default_target_fps
+        per_stream_targets[stream_name] = float(target_fps)
+    
+    print(f"INFO: per-stream target FPS map: {per_stream_targets}")
+    return per_stream_targets
+
+def get_mean_target_fps(stream_target_fps, fallback_target_fps):
+    target_fps_values = [float(v) for v in stream_target_fps.values() if float(v) > 0]
+    return statistics.mean(target_fps_values) if target_fps_values else float(fallback_target_fps)
 
 def measure_pipeline_memory(env_vars, compose_files, results_dir, container_name):
     
@@ -618,18 +670,35 @@ def run_pipeline_iterations(
         f"{total_pipeline_latency_per_stream} "
         f"for {num_pipelines} pipeline(s)")
 
-        # --- Decide scaling logic ---
-        pass_threshold = target_fps * pass_tolerance_ratio
-        fail_threshold = pass_threshold - hysteresis_fps
+        # --- Decide scaling logic (per-stream thresholds) ---
+        stream_target_fps = build_per_stream_target_fps(
+            stream_fps_dict, target_fps
+        )
+
+        pass_thresholds = {
+            name: stream_target_fps[name] * pass_tolerance_ratio
+            for name in stream_fps_dict
+        }
+
+        fail_thresholds = {
+            name: pass_thresholds[name] - hysteresis_fps
+            for name in stream_fps_dict
+        }
+
         passing_streams = {
             name: fps for name, fps in stream_fps_dict.items()
-            if fps >= pass_threshold
+            if fps >= pass_thresholds[name]
         }
         failing_streams = {
             name: fps for name, fps in stream_fps_dict.items()
-            if fps < fail_threshold
+            if fps < fail_thresholds[name]
         }
+        print('pass_thresholds:', pass_thresholds)
+        print('fail_thresholds:', fail_thresholds)
+        print('passing_streams:', passing_streams)
+        print('failing_streams:', failing_streams)
         all_streams_meet_target = len(passing_streams) == len(stream_fps_dict)
+        print("INFO: All streams meet target" if all_streams_meet_target else "INFO: Not all streams meet target")
 
         if not in_decrement:
             if all_streams_meet_target:
@@ -641,12 +710,15 @@ def run_pipeline_iterations(
                     per_stream_values = list(stream_fps_dict.values())
                     robust_per_stream = statistics.median(per_stream_values) if per_stream_values else total_fps_per_stream
                     conservative_per_stream = min(total_fps_per_stream, robust_per_stream)
-                    increments = int(conservative_per_stream / target_fps)
+                    average_target_fps = get_mean_target_fps(stream_target_fps, target_fps)
+                    print('mean target fps:', average_target_fps)
+                    increments = int(conservative_per_stream / average_target_fps)
                     if increments == 1:
                         increments = MAX_GUESS_INCREMENTS
                 print(
-                    f"✅ All streams meet pass threshold ({pass_threshold:.4f}) "
-                    f"for target FPS ({target_fps}). Incrementing pipeline no. by {increments}"
+                    f"✅ All streams meet pass thresholds {pass_thresholds} "
+                    f"for target FPS map {stream_target_fps}. "
+                    f"Incrementing pipeline no. by {increments}"
                 )
             else:
                 pass_window_count = 0
@@ -656,25 +728,26 @@ def run_pipeline_iterations(
                     in_decrement = True
                     fail_window_count = 0
                     print(
-                        f"⚠️ Pass threshold ({pass_threshold:.4f}) not met in streams: "
-                        f"{stream_fps_dict}. Observed {consecutive_fail_windows} consecutive "
+                        f"⚠️ Pass thresholds not met in streams: observed={stream_fps_dict}, "
+                        f"pass_thresholds={pass_thresholds}. "
+                        f"Observed {consecutive_fail_windows} consecutive "
                         f"below-threshold windows; starting to decrement pipelines by 1..."
                     )
                 else:
                     increments = 0
                     if failing_streams:
                         print(
-                            f"⚠️ Below hysteresis fail threshold ({fail_threshold:.4f}) in streams: "
-                            f"{failing_streams}. Fail window "
-                            f"{fail_window_count}/{consecutive_fail_windows}; holding pipeline "
-                            f"count at {num_pipelines} for confirmation."
+                            f"⚠️ Below hysteresis fail thresholds in streams: "
+                            f"observed={failing_streams}, fail_thresholds={fail_thresholds}. "
+                            f"Fail window {fail_window_count}/{consecutive_fail_windows}; "
+                            f"holding pipeline count at {num_pipelines} for confirmation."
                         )
                     else:
                         print(
-                            f"INFO: Streams are below pass threshold ({pass_threshold:.4f}) but "
-                            f"above fail threshold ({fail_threshold:.4f}). Fail window "
-                            f"{fail_window_count}/{consecutive_fail_windows}; holding pipeline "
-                            f"count at {num_pipelines} for confirmation."
+                            f"INFO: Streams are below pass thresholds ({pass_thresholds}) but "
+                            f"above fail thresholds ({fail_thresholds}). "
+                            f"Fail window {fail_window_count}/{consecutive_fail_windows}; "
+                            f"holding pipeline count at {num_pipelines} for confirmation."
                         )
         else:
             # --- In decrement phase ---
@@ -684,11 +757,13 @@ def run_pipeline_iterations(
                 if pass_window_count >= consecutive_pass_windows:
                     print(
                         f"✅ Found maximum number of pipelines to reach "
-                        f"target FPS {target_fps}")
+                        f"target FPS map {stream_target_fps}"
+                    )
                     meet_target_fps = True
                     print(
-                        f"🎯 Max stream density achieved for target FPS "
-                        f"{target_fps} is {num_pipelines}")
+                        f"🎯 Max stream density achieved for target FPS map "
+                        f"{stream_target_fps} is {num_pipelines}"
+                    )
                     increments = 0
                 else:
                     increments = 0
@@ -701,9 +776,9 @@ def run_pipeline_iterations(
                 pass_window_count = 0
                 fail_window_count = 0
                 print(
-                    f"already reached num. pipeline 1, and "
-                    f"the fps per stream is {total_fps_per_stream} "
-                    f"but target FPS is {target_fps}")
+                    f"already reached num. pipeline 1, and the fps per stream is "
+                    f"{total_fps_per_stream} but target FPS map is {stream_target_fps}"
+                )
                 meet_target_fps = False
                 break
             else:
@@ -715,30 +790,32 @@ def run_pipeline_iterations(
                     if failing_streams:
                         print(
                             f"decrementing number of pipelines {num_pipelines} by 1 "
-                            f"because streams are below hysteresis fail threshold {fail_threshold:.4f}: "
-                            f"{failing_streams}"
+                            f"because streams are below hysteresis fail thresholds. "
+                            f"observed={failing_streams}, fail_thresholds={fail_thresholds}"
                         )
                     else:
                         print(
                             f"decrementing number of pipelines {num_pipelines} by 1 "
-                            f"because streams stayed below pass threshold ({pass_threshold:.4f}) "
-                            f"for {consecutive_fail_windows} windows."
+                            f"because streams stayed below pass thresholds "
+                            f"({pass_thresholds}) for {consecutive_fail_windows} windows."
                         )
                 else:
                     increments = 0
                     if failing_streams:
                         print(
-                            f"INFO: Below fail threshold ({fail_threshold:.4f}) in streams "
-                            f"{failing_streams}. Fail window {fail_window_count}/{consecutive_fail_windows}; "
+                            f"INFO: Below fail thresholds in streams. "
+                            f"observed={failing_streams}, fail_thresholds={fail_thresholds}. "
+                            f"Fail window {fail_window_count}/{consecutive_fail_windows}; "
                             f"holding pipeline count at {num_pipelines} for confirmation."
                         )
                     else:
                         print(
-                            f"INFO: Below pass threshold ({pass_threshold:.4f}) but above fail threshold "
-                            f"({fail_threshold:.4f}). Fail window {fail_window_count}/{consecutive_fail_windows}; "
+                            f"INFO: Below pass thresholds ({pass_thresholds}) but above "
+                            f"fail thresholds ({fail_thresholds}). "
+                            f"Fail window {fail_window_count}/{consecutive_fail_windows}; "
                             f"holding pipeline count at {num_pipelines} for confirmation."
                         )
-
+                        
         # --- Update pipeline count ---
         num_pipelines += increments
         if num_pipelines <= 0:

--- a/benchmark-scripts/stream_density.py
+++ b/benchmark-scripts/stream_density.py
@@ -13,7 +13,7 @@ import sys
 import re
 import statistics
 import psutil
-import json 
+import json
 
 # Constants:
 TARGET_FPS_KEY = "TARGET_FPS"
@@ -43,30 +43,45 @@ def build_per_stream_target_fps(stream_fps_dict, default_target_fps):
     """Build stream-level FPS targets from camera config."""
     # Get camera config path
     camera_stream = os.getenv(CAMERA_STREAM_KEY, "camera_to_workload.json")
+    config_path = camera_stream if os.path.isabs(camera_stream) else os.path.normpath(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "configs", camera_stream)
+    )
+
+    # Build unified stream index -> target FPS mapping (cached by config path + mtime)
+    cache = getattr(build_per_stream_target_fps, "_camera_config_cache", {})
     
-    config_path = camera_stream if os.path.isabs(camera_stream) else os.path.abspath(camera_stream)
+    # Create cache key that includes file modification time to detect file changes
+    file_mtime = os.path.getmtime(config_path) if os.path.isfile(config_path) else 0
+    cache_key = (config_path, file_mtime)
     
-    # Build unified stream index -> target FPS mapping
-    stream_idx_to_target_fps = {}
-    total_cameras = 0
-    if os.path.isfile(config_path):
-        try:
-            with open(config_path, "r") as f:
-                cameras = json.load(f).get("lane_config", {}).get("cameras", [])
-            total_cameras = len(cameras)
-            for idx, cam in enumerate(cameras):
-                if isinstance(cam, dict):
-                    try:
-                        fps_value = float(cam.get("targetFps", 0))
-                        if fps_value > 0:
-                            stream_idx_to_target_fps[idx] = fps_value
-                    except (TypeError, ValueError):
-                        pass
-        except (IOError, ValueError) as e:
-            print(f"WARN: Failed to load camera config {config_path}: {e}")
+    cached = cache.get(cache_key)
+    if cached is not None:
+        stream_idx_to_target_fps, total_cameras = cached
     else:
-        print(f"WARN: camera configuration not found at {config_path}. Using default target FPS for all streams.")
-    
+        stream_idx_to_target_fps = {}
+        total_cameras = 0
+        if os.path.isfile(config_path):
+            try:
+                with open(config_path, "r") as f:
+                    cameras = json.load(f).get("lane_config", {}).get("cameras", [])
+                total_cameras = len(cameras)
+                for idx, cam in enumerate(cameras):
+                    if isinstance(cam, dict):
+                        try:
+                            fps_value = float(cam.get("targetFps", 0))
+                            if fps_value > 0:
+                                stream_idx_to_target_fps[idx] = fps_value
+                        except (TypeError, ValueError):
+                            pass
+                cache[cache_key] = (dict(stream_idx_to_target_fps), int(total_cameras))
+                build_per_stream_target_fps._camera_config_cache = cache
+            except (IOError, ValueError) as e:
+                print(f"WARN: Failed to load camera config {config_path}: {e}")
+        else:
+            print(
+                f"WARN: camera configuration not found at {config_path}. Using default target FPS for all streams."
+            )
+            
     # Compile regex once (if needed for stream name parsing)
     stream_pattern = re.compile(r"pipeline_stream(\d+)")
     per_stream_targets = {}
@@ -81,7 +96,7 @@ def build_per_stream_target_fps(stream_fps_dict, default_target_fps):
         per_stream_targets[stream_name] = float(target_fps)
     
     if os.getenv("STREAM_DENSITY_DEBUG", "0") == "1":
-         print(f"INFO: per-stream target FPS map: {per_stream_targets}")
+        print(f"INFO: per-stream target FPS map: {per_stream_targets}")
     return per_stream_targets
 
 def get_mean_target_fps(stream_target_fps, fallback_target_fps):
@@ -694,10 +709,10 @@ def run_pipeline_iterations(
         }
         all_streams_meet_target = len(passing_streams) == len(stream_fps_dict)
         if os.getenv("STREAM_DENSITY_DEBUG", "0") == "1":
-             print('pass_thresholds:', pass_thresholds)
-             print('fail_thresholds:', fail_thresholds)
-             print('passing_streams:', passing_streams)
-             print('failing_streams:', failing_streams)
+            print('pass_thresholds:', pass_thresholds)
+            print('fail_thresholds:', fail_thresholds)
+            print('passing_streams:', passing_streams)
+            print('failing_streams:', failing_streams)
         print("INFO: All streams meet target" if all_streams_meet_target else "INFO: Not all streams meet target")
 
         if not in_decrement:
@@ -711,7 +726,8 @@ def run_pipeline_iterations(
                     robust_per_stream = statistics.median(per_stream_values) if per_stream_values else total_fps_per_stream
                     conservative_per_stream = min(total_fps_per_stream, robust_per_stream)
                     average_target_fps = get_mean_target_fps(stream_target_fps, target_fps)
-                    print('mean target fps:', average_target_fps)
+                    if os.getenv("STREAM_DENSITY_DEBUG", "0") == "1":
+                        print('mean target fps:', average_target_fps)
                     increments = int(conservative_per_stream / average_target_fps)
                     if increments == 1:
                         increments = MAX_GUESS_INCREMENTS

--- a/benchmark-scripts/stream_density_test.py
+++ b/benchmark-scripts/stream_density_test.py
@@ -7,6 +7,8 @@
 import mock
 import subprocess  # nosec B404
 import unittest
+import tempfile
+import json
 from unittest.mock import patch, mock_open, MagicMock
 import stream_density
 from stream_density import validate_and_setup_env, ArgumentError
@@ -20,6 +22,69 @@ import os
 
 
 class Testing(unittest.TestCase):
+    def test_build_per_stream_target_fps_mixed_values(self):
+        stream_fps_dict = {
+            'pipeline_stream0': 10.0,
+            'pipeline_stream1': 10.0,
+            'pipeline_stream2': 10.0,
+            'pipeline_stream3': 10.0,
+            'pipeline_stream4': 10.0,
+        }
+        camera_config = {
+            'lane_config': {
+                'cameras': [
+                    {'targetFps': 30},
+                    {'targetFps': '15.5'},
+                    {'targetFps': 0},
+                    {'targetFps': -7},
+                    {'targetFps': 'bad'},
+                ]
+            }
+        }
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:
+            json.dump(camera_config, temp_file)
+            temp_file.flush()
+            temp_config_path = temp_file.name
+
+        try:
+            with patch.dict(os.environ, {'CAMERA_STREAM': temp_config_path}, clear=False):
+                result = stream_density.build_per_stream_target_fps(
+                    stream_fps_dict, default_target_fps=14.95
+                )
+
+            expected = {
+                'pipeline_stream0': 30.0,
+                'pipeline_stream1': 15.5,
+                'pipeline_stream2': 14.95,
+                'pipeline_stream3': 14.95,
+                'pipeline_stream4': 14.95,
+            }
+            self.assertEqual(result, expected)
+        finally:
+            if os.path.exists(temp_config_path):
+                os.remove(temp_config_path)
+
+    def test_build_per_stream_target_fps_missing_config_uses_default(self):
+        stream_fps_dict = {
+            'pipeline_stream0': 10.0,
+            'pipeline_stream7': 10.0,
+            'stream_without_index': 10.0,
+        }
+        missing_path = '/tmp/non-existent-camera-config-for-test.json'
+
+        with patch.dict(os.environ, {'CAMERA_STREAM': missing_path}, clear=False):
+            result = stream_density.build_per_stream_target_fps(
+                stream_fps_dict, default_target_fps=22.0
+            )
+
+        expected = {
+            'pipeline_stream0': 22.0,
+            'pipeline_stream7': 22.0,
+            'stream_without_index': 22.0,
+        }
+        self.assertEqual(result, expected)
+
     def test_is_env_non_empty(self):
         sys_env = os.environ.copy()
         sys_env["EMPTY"] = ""

--- a/benchmark-scripts/stream_density_test.py
+++ b/benchmark-scripts/stream_density_test.py
@@ -71,8 +71,10 @@ class Testing(unittest.TestCase):
             'pipeline_stream7': 10.0,
             'stream_without_index': 10.0,
         }
-        missing_path = '/tmp/non-existent-camera-config-for-test.json'
-
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_path = os.path.join(tmpdir, 'non-existent-camera-config-for-test.json')
+        
         with patch.dict(os.environ, {'CAMERA_STREAM': missing_path}, clear=False):
             result = stream_density.build_per_stream_target_fps(
                 stream_fps_dict, default_target_fps=22.0


### PR DESCRIPTION
Evaluate stream density per camera target FPS so mixed-camera ASC bundles stop only when each stream meets its own threshold.

Resolves: #235

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/performance-tools/blob/main/CONTRIBUTING.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [x] Unit Tests have been added for new changes
- [x] Updated Documentation as relevant to the changes
- [x] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
This PR updates stream-density stopping logic to use per-stream target FPS, so mixed-camera ASC bundles stop only when each stream meets its own threshold.

## Issue this PR will close

close: #235 

## Anything the reviewer should know when reviewing this PR?

Per-stream pass/fail thresholds with hysteresis are now used instead of a single shared FPS target, and target FPS thresholds are taken from camera config JSON files.

## Test Instructions if applicable

- Use a camera config with different targetFps values per camera.
- Run stream density benchmark.
- Confirm each stream is checked against its own threshold before stopping.

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/performance-tools )
